### PR TITLE
Feature/moneymong 209 네트워크 에러 핸들링 개발

### DIFF
--- a/core/common/src/main/java/com/moneymong/moneymong/common/error/Error.kt
+++ b/core/common/src/main/java/com/moneymong/moneymong/common/error/Error.kt
@@ -11,15 +11,4 @@ sealed interface MoneyMongError {
     data object NetworkConnectionError : MoneyMongError {
         override val message: String = "네트워크 연결을 확인해주세요"
     }
-
-    fun getErrorByStatusCode(statusCode: Int, message: String): MoneyMongError {
-        return when (statusCode) {
-            400 -> HttpError.BadRequestError(message = message)
-            401 -> HttpError.UnauthorizedError(message = message)
-            403 -> HttpError.ForbiddenError(message = message)
-            404 -> HttpError.NotFoundError(message = message)
-            500 -> HttpError.InternalServerError(message = message)
-            else -> UnExpectedError
-        }
-    }
 }

--- a/core/common/src/main/java/com/moneymong/moneymong/common/error/Error.kt
+++ b/core/common/src/main/java/com/moneymong/moneymong/common/error/Error.kt
@@ -1,0 +1,25 @@
+package com.moneymong.moneymong.common.error
+
+sealed interface MoneyMongError {
+
+    val message: String
+
+    data object UnExpectedError : MoneyMongError {
+        override val message: String = "머니몽 서비스에 문제가 발생했어요"
+    }
+
+    data object NetworkConnectionError : MoneyMongError {
+        override val message: String = "네트워크 연결을 확인해주세요"
+    }
+
+    fun getErrorByStatusCode(statusCode: Int, message: String): MoneyMongError {
+        return when (statusCode) {
+            400 -> HttpError.BadRequestError(message = message)
+            401 -> HttpError.UnauthorizedError(message = message)
+            403 -> HttpError.ForbiddenError(message = message)
+            404 -> HttpError.NotFoundError(message = message)
+            500 -> HttpError.InternalServerError(message = message)
+            else -> UnExpectedError
+        }
+    }
+}

--- a/core/common/src/main/java/com/moneymong/moneymong/common/error/HttpError.kt
+++ b/core/common/src/main/java/com/moneymong/moneymong/common/error/HttpError.kt
@@ -1,0 +1,29 @@
+package com.moneymong.moneymong.common.error
+
+sealed interface HttpError : MoneyMongError {
+
+    /**
+     * 400 Bad Request
+     */
+    data class BadRequestError(override val message: String) : HttpError
+
+    /**
+     * 401 Unauthorized
+     */
+    data class UnauthorizedError(override val message: String) : HttpError
+
+    /**
+     * 403 Forbidden
+     */
+    data class ForbiddenError(override val message: String) : HttpError
+
+    /**
+     * 404 Not Found
+     */
+    data class NotFoundError(override val message: String) : HttpError
+
+    /**
+     * 500 Internal Server Error
+     */
+    data class InternalServerError(override val message: String) : HttpError
+}

--- a/core/common/src/main/java/com/moneymong/moneymong/common/error/HttpError.kt
+++ b/core/common/src/main/java/com/moneymong/moneymong/common/error/HttpError.kt
@@ -27,3 +27,14 @@ sealed interface HttpError : MoneyMongError {
      */
     data class InternalServerError(override val message: String) : HttpError
 }
+
+fun getErrorByStatusCode(statusCode: Int, message: String): MoneyMongError {
+    return when (statusCode) {
+        400 -> HttpError.BadRequestError(message = message)
+        401 -> HttpError.UnauthorizedError(message = message)
+        403 -> HttpError.ForbiddenError(message = message)
+        404 -> HttpError.NotFoundError(message = message)
+        500 -> HttpError.InternalServerError(message = message)
+        else -> MoneyMongError.UnExpectedError
+    }
+}

--- a/core/common/src/main/java/com/moneymong/moneymong/common/result/Result.kt
+++ b/core/common/src/main/java/com/moneymong/moneymong/common/result/Result.kt
@@ -1,0 +1,31 @@
+package com.moneymong.moneymong.common.result
+
+import com.moneymong.moneymong.common.error.MoneyMongError
+
+sealed interface MoneyMongResult<out T> {
+    data class Success<T>(val data: T) : MoneyMongResult<T>
+    data class Failure(val error: MoneyMongError) : MoneyMongResult<Nothing>
+}
+
+inline fun <R, T> MoneyMongResult<T>.map(
+    transform: (value: T?) -> R
+): MoneyMongResult<R> {
+    return when (this) {
+        is MoneyMongResult.Success -> MoneyMongResult.Success(transform(data))
+        is MoneyMongResult.Failure -> MoneyMongResult.Failure(error)
+    }
+}
+
+inline fun <T> MoneyMongResult<T>.onSuccess(
+    action: (value: T) -> Unit
+): MoneyMongResult<T> {
+    if (this is MoneyMongResult.Success) action(data)
+    return this
+}
+
+inline fun <T> MoneyMongResult<T>.onFailure(
+    action: (error: MoneyMongError) -> Unit
+): MoneyMongResult<T> {
+    if (this is MoneyMongResult.Failure) action(error)
+    return this
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.common)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.appcompat)

--- a/core/network/src/main/java/com/moneymong/moneymong/network/adapter/ResultCallAdapter.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/adapter/ResultCallAdapter.kt
@@ -1,7 +1,7 @@
 package com.moneymong.moneymong.network.adapter
 
 import com.moneymong.moneymong.common.error.MoneyMongError
-import com.moneymong.moneymong.common.error.MoneyMongError.UnExpectedError.getErrorByStatusCode
+import com.moneymong.moneymong.common.error.getErrorByStatusCode
 import com.moneymong.moneymong.common.result.MoneyMongResult
 import com.moneymong.moneymong.network.response.fromJsonToErrorResponse
 import okhttp3.Request

--- a/core/network/src/main/java/com/moneymong/moneymong/network/adapter/ResultCallAdapter.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/adapter/ResultCallAdapter.kt
@@ -1,0 +1,83 @@
+package com.moneymong.moneymong.network.adapter
+
+import com.moneymong.moneymong.common.error.MoneyMongError
+import com.moneymong.moneymong.common.error.MoneyMongError.UnExpectedError.getErrorByStatusCode
+import com.moneymong.moneymong.common.result.MoneyMongResult
+import com.moneymong.moneymong.network.response.fromJsonToErrorResponse
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.IOException
+import java.lang.reflect.Type
+
+internal class ResultCallAdapter(
+    private val responseType: Type
+) : CallAdapter<Type, Call<MoneyMongResult<Type>>> {
+
+    override fun responseType(): Type = responseType
+
+    override fun adapt(call: Call<Type>): Call<MoneyMongResult<Type>> = ResultCall(call)
+}
+
+
+private class ResultCall<T>(
+    private val delegate: Call<T>,
+) : Call<MoneyMongResult<T>> {
+
+    override fun enqueue(callback: Callback<MoneyMongResult<T>>) {
+        delegate.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                callback.onResponse(this@ResultCall, Response.success(response.toMoneyMongResult()))
+            }
+
+            private fun Response<T>.toMoneyMongResult(): MoneyMongResult<T> {
+                val body = body()
+                val errorBody = errorBody()?.string()
+
+                if (isSuccessful && body != null) {
+                    return MoneyMongResult.Success(body)
+                }
+
+                if (body == null || errorBody == null) {
+                    return MoneyMongResult.Failure(MoneyMongError.UnExpectedError)
+                }
+
+                val errorResponse = fromJsonToErrorResponse(errorBody)
+                val httpError = getErrorByStatusCode(
+                    statusCode = errorResponse.status,
+                    message = errorResponse.message
+                )
+                return MoneyMongResult.Failure(httpError)
+            }
+
+            override fun onFailure(call: Call<T>, t: Throwable) {
+                val failure = when (t) {
+                    is IOException -> MoneyMongError.NetworkConnectionError
+                    else -> MoneyMongError.UnExpectedError
+                }
+                callback.onResponse(
+                    this@ResultCall,
+                    Response.success(MoneyMongResult.Failure(failure))
+                )
+            }
+        })
+    }
+
+
+    override fun clone(): Call<MoneyMongResult<T>> = ResultCall(delegate.clone())
+
+    override fun execute(): Response<MoneyMongResult<T>> = throw UnsupportedOperationException()
+
+    override fun isExecuted(): Boolean = delegate.isExecuted
+
+    override fun cancel() = delegate.cancel()
+
+    override fun isCanceled(): Boolean = delegate.isCanceled
+
+    override fun request(): Request = delegate.request()
+
+    override fun timeout(): Timeout = delegate.timeout()
+}

--- a/core/network/src/main/java/com/moneymong/moneymong/network/adapter/ResultCallAdapterFactory.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/adapter/ResultCallAdapterFactory.kt
@@ -1,0 +1,34 @@
+package com.moneymong.moneymong.network.adapter
+
+import com.moneymong.moneymong.common.result.MoneyMongResult
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class ResultCallAdapterFactory private constructor() : CallAdapter.Factory() {
+
+    companion object {
+        fun create() = ResultCallAdapterFactory()
+    }
+
+
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+
+        val wrapperType = getParameterUpperBound(0, returnType as ParameterizedType)
+        if (getRawType(wrapperType) != MoneyMongResult::class.java) {
+            return null
+        }
+
+        val responseType = getParameterUpperBound(0, wrapperType as ParameterizedType)
+        return ResultCallAdapter(responseType)
+    }
+}

--- a/core/network/src/main/java/com/moneymong/moneymong/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/di/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.chuckerteam.chucker.api.RetentionManager
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.moneymong.moneymong.network.BuildConfig
+import com.moneymong.moneymong.network.adapter.ResultCallAdapterFactory
 import com.moneymong.moneymong.network.util.MoneyMongTokenAuthenticator
 import dagger.Module
 import dagger.Provides
@@ -70,6 +71,7 @@ object NetworkModule {
         gson: Gson
     ): Retrofit = Retrofit.Builder().apply {
         addConverterFactory(GsonConverterFactory.create(gson))
+        addCallAdapterFactory(ResultCallAdapterFactory.create())
         client(okHttpClient)
         baseUrl("")
     }.build()

--- a/core/network/src/main/java/com/moneymong/moneymong/network/response/ErrorResponse.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/response/ErrorResponse.kt
@@ -1,0 +1,12 @@
+package com.moneymong.moneymong.network.response
+
+import com.google.gson.Gson
+
+data class ErrorResponse(
+    val status: Int,
+    val message: String
+)
+
+fun fromJsonToErrorResponse(json: String): ErrorResponse {
+    return Gson().fromJson(json, ErrorResponse::class.java)
+}


### PR DESCRIPTION
## 요약
네트워크 에러 핸들링을 개발했습니다!🙂
## 작업내용
- MoneyMongResult 구현
- MoneyMongError 구현
- ErrorResponse 구현
- ResultCallAdapter 개발 및 적용

## 기타
- 에러 메시지는 임의로 해뒀으며 추후 논의가 필요합니다!
- `MoneyMongResult.map` 은 추후 사용될 수도 있다고 판단하여 만들어뒀습니다!
### 사용법(예시)
**api(service)**
```kotlin
interface TestApi {
    @GET("/test/1")
    suspend fun test(): MoneyMongResult<TestResponse>
}
```

**use**
```kotlin
getAgency()
    .onSuccess { agency ->
        // showAgency(agency)
    }.onFailure { error ->
        when (error) {
            is MoneyMongError.NetworkConnectionError -> {
                // showNetworkErrorDialog(error.message)
            }

            else -> {
                // showErrorDialog(error.message)
            }
        }
    }
```