### PR TITLE
Feature/moneymong 222 소속 등록,조회 서버 연동

### DIFF
--- a/core/network/src/main/java/com/moneymong/moneymong/network/api/AgencyApi.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/api/AgencyApi.kt
@@ -1,0 +1,27 @@
+package com.moneymong.moneymong.network.api
+
+import com.moneymong.moneymong.network.request.agency.AgencyRegisterRequest
+import com.moneymong.moneymong.network.response.agency.AgenciesGetResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+
+interface AgencyApi {
+
+    @GET("api/v1/agencies")
+    suspend fun getAgencies(
+        @Header("Authorization") header: String = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwidXNlcklkIjozLCJpYXQiOjE3MDQ3MTU0NTEsImV4cCI6MTczNjI3MzA1MX0.2yYEy71Gz4YIz0DYzlx0glYMgZA0JAZs05jsVRvvQx4",
+        @Query("page") page: Int,
+        @Query("size") size: Int
+    ): Result<AgenciesGetResponse>
+
+
+    @POST("api/v1/agencies")
+    suspend fun registerAgency(
+        @Header("Authorization") header: String = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjoiUk9MRV9VU0VSIiwidXNlcklkIjozLCJpYXQiOjE3MDQ3MTU0NTEsImV4cCI6MTczNjI3MzA1MX0.2yYEy71Gz4YIz0DYzlx0glYMgZA0JAZs05jsVRvvQx4",
+        @Body request: AgencyRegisterRequest,
+    ): Result<Unit>
+}

--- a/core/network/src/main/java/com/moneymong/moneymong/network/api/MoneyMongApi.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/api/MoneyMongApi.kt
@@ -9,7 +9,7 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 
-interface AgencyApi {
+interface MoneyMongApi {
 
     @GET("api/v1/agencies")
     suspend fun getAgencies(

--- a/core/network/src/main/java/com/moneymong/moneymong/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/di/NetworkModule.kt
@@ -8,7 +8,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.moneymong.moneymong.network.BuildConfig
 import com.moneymong.moneymong.network.adapter.ResultCallAdapterFactory
-import com.moneymong.moneymong.network.api.AgencyApi
+import com.moneymong.moneymong.network.api.MoneyMongApi
 import com.moneymong.moneymong.network.util.MoneyMongTokenAuthenticator
 import dagger.Module
 import dagger.Provides
@@ -79,6 +79,6 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideAgencyApi(retrofit: Retrofit): AgencyApi =
-        retrofit.create(AgencyApi::class.java)
+    fun provideMoneyMongApi(retrofit: Retrofit): MoneyMongApi =
+        retrofit.create(MoneyMongApi::class.java)
 }

--- a/core/network/src/main/java/com/moneymong/moneymong/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.moneymong.moneymong.network.BuildConfig
 import com.moneymong.moneymong.network.adapter.ResultCallAdapterFactory
+import com.moneymong.moneymong.network.api.AgencyApi
 import com.moneymong.moneymong.network.util.MoneyMongTokenAuthenticator
 import dagger.Module
 import dagger.Provides
@@ -73,8 +74,11 @@ object NetworkModule {
         addConverterFactory(GsonConverterFactory.create(gson))
         addCallAdapterFactory(ResultCallAdapterFactory.create())
         client(okHttpClient)
-        baseUrl("")
+        baseUrl("https://dev.moneymong.site/")
     }.build()
 
-    // TODO Api Provider
+    @Provides
+    @Singleton
+    fun provideAgencyApi(retrofit: Retrofit): AgencyApi =
+        retrofit.create(AgencyApi::class.java)
 }

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/impl/AgencyRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/impl/AgencyRemoteDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.moneymong.moneymong.data.datasource.impl
+
+import com.moneymong.moneymong.data.datasource.AgencyRemoteDataSource
+import com.moneymong.moneymong.network.api.AgencyApi
+import com.moneymong.moneymong.network.request.agency.AgencyRegisterRequest
+import com.moneymong.moneymong.network.response.agency.AgenciesGetResponse
+import javax.inject.Inject
+
+class AgencyRemoteDataSourceImpl @Inject constructor(
+    private val agencyApi: AgencyApi
+) : AgencyRemoteDataSource {
+
+    override suspend fun registerAgency(request: AgencyRegisterRequest): Result<Unit> {
+        return agencyApi.registerAgency(request = request)
+    }
+
+    override suspend fun getAgencies(page: Int, size: Int): Result<AgenciesGetResponse> {
+        return agencyApi.getAgencies(page = page, size = size)
+    }
+}

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/impl/AgencyRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/impl/AgencyRemoteDataSourceImpl.kt
@@ -1,20 +1,20 @@
 package com.moneymong.moneymong.data.datasource.impl
 
 import com.moneymong.moneymong.data.datasource.AgencyRemoteDataSource
-import com.moneymong.moneymong.network.api.AgencyApi
+import com.moneymong.moneymong.network.api.MoneyMongApi
 import com.moneymong.moneymong.network.request.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.network.response.agency.AgenciesGetResponse
 import javax.inject.Inject
 
 class AgencyRemoteDataSourceImpl @Inject constructor(
-    private val agencyApi: AgencyApi
+    private val moneyMongApi: MoneyMongApi
 ) : AgencyRemoteDataSource {
 
     override suspend fun registerAgency(request: AgencyRegisterRequest): Result<Unit> {
-        return agencyApi.registerAgency(request = request)
+        return moneyMongApi.registerAgency(request = request)
     }
 
     override suspend fun getAgencies(page: Int, size: Int): Result<AgenciesGetResponse> {
-        return agencyApi.getAgencies(page = page, size = size)
+        return moneyMongApi.getAgencies(page = page, size = size)
     }
 }

--- a/data/src/main/java/com/moneymong/moneymong/data/di/DataSourceModule.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/di/DataSourceModule.kt
@@ -1,7 +1,7 @@
 package com.moneymong.moneymong.data.di
 
 import com.moneymong.moneymong.data.datasource.AgencyRemoteDataSource
-import com.moneymong.moneymong.data.datasource.mock.AgencyRemoteDataSourceMock
+import com.moneymong.moneymong.data.datasource.impl.AgencyRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,6 +13,6 @@ interface DataSourceModule {
 
     @Binds
     fun bindAgencyRemoteDataSource(
-        agencyRemoteDataSourceMock: AgencyRemoteDataSourceMock
+        agencyRemoteDataSourceImpl: AgencyRemoteDataSourceImpl
     ): AgencyRemoteDataSource
 }

--- a/data/src/main/java/com/moneymong/moneymong/data/pagingsource/AgencyPagingSource.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/pagingsource/AgencyPagingSource.kt
@@ -8,6 +8,7 @@ import com.moneymong.moneymong.network.response.agency.AgencyGetResponse
 class AgencyPagingSource(
     private val dataSource: AgencyRemoteDataSource,
 ) : PagingSource<Int, AgencyGetResponse>() {
+
     override fun getRefreshKey(state: PagingState<Int, AgencyGetResponse>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             val anchorPage = state.closestPageToPosition(anchorPosition)
@@ -18,7 +19,7 @@ class AgencyPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, AgencyGetResponse> {
         val page = params.key ?: START_PAGE
         val size = params.loadSize
-        return dataSource.getAgencies(page, size).fold(
+        return dataSource.getAgencies(page = page, size = size).fold(
             onSuccess = {
                 LoadResult.Page(
                     data = it.agencies,

--- a/data/src/main/java/com/moneymong/moneymong/data/repository/AgencyRepositoryImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/repository/AgencyRepositoryImpl.kt
@@ -25,7 +25,7 @@ class AgencyRepositoryImpl @Inject constructor(
 
     override fun getAgencies(): Flow<PagingData<AgencyGetEntity>> {
         return Pager(
-            config = PagingConfig(pageSize = 10),
+            config = PagingConfig(pageSize = 10, initialLoadSize = 10),
             pagingSourceFactory = { AgencyPagingSource(agencyRemoteDataSource) }
         ).flow.map { pagingData ->
             pagingData.map { response ->

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
@@ -51,9 +51,9 @@ fun AgencyRegisterScreen(
 
     if (state.visibleOutDialog) {
         AgencyOutDialog(
-            onDismissRequest = { viewModel.changeVisibleDialog(false) },
-            onPositive = { viewModel.onDialogPositiveButtonClicked() },
-            onNegative = { viewModel.changeVisibleDialog(false) }
+            onDismissRequest = { viewModel.changeOutDialogVisibility(false) },
+            onPositive = viewModel::navigateUp,
+            onNegative = { viewModel.changeOutDialogVisibility(false) }
         )
     }
 
@@ -68,7 +68,7 @@ fun AgencyRegisterScreen(
                 .align(Alignment.End)
                 .padding(vertical = 10.dp)
                 .size(24.dp)
-                .noRippleClickable(onClick = { viewModel.changeVisibleDialog(true) }),
+                .noRippleClickable(onClick = { viewModel.changeOutDialogVisibility(true) }),
             painter = painterResource(id = R.drawable.ic_close_default),
             tint = Gray07,
             contentDescription = null
@@ -77,9 +77,9 @@ fun AgencyRegisterScreen(
         AgencyResisterContentView(
             modifier = Modifier.weight(1f),
             agencyType = state.agencyType,
-            onAgencyTypeChange = viewModel::onAgencyTypeChanged,
+            onAgencyTypeChange = viewModel::changeAgencyType,
             agencyName = state.agencyName,
-            onAgencyNameChange = viewModel::onAgencyNameChanged,
+            onAgencyNameChange = viewModel::changeAgencyName,
             changeNameTextFieldIsError = viewModel::changeNameTextFieldIsError,
         )
         val canRegister = state.agencyName.text.isNotEmpty() && state.nameTextFieldIsError.not()
@@ -87,7 +87,7 @@ fun AgencyRegisterScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 28.dp),
-            onClick = viewModel::onRegisterButtonClicked,
+            onClick = viewModel::registerAgency,
             text = "등록하기",
             enabled = canRegister
         )

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
@@ -18,8 +18,23 @@ class AgencyRegisterViewModel @Inject constructor(
     private val registerAgencyUseCase: RegisterAgencyUseCase
 ) : BaseViewModel<AgencyRegisterState, AgencyRegisterSideEffect>(AgencyRegisterState()) {
 
+    fun navigateUp() = eventEmit(sideEffect = AgencyRegisterSideEffect.NavigateUp)
+
+    fun registerAgency() = intent {
+        registerAgencyUseCase(
+            data = AgencyRegisterParam(
+                name = state.agencyName.text,
+                type = state.agencyType.toParam()
+            )
+        ).onSuccess {
+            postSideEffect(AgencyRegisterSideEffect.NavigateToComplete)
+        }.onFailure {
+            // TODO: 에러 처라
+        }
+    }
+
     @OptIn(OrbitExperimental::class)
-    fun onAgencyNameChanged(agencyName: TextFieldValue) = blockingIntent {
+    fun changeAgencyName(agencyName: TextFieldValue) = blockingIntent {
         reduce {
             state.copy(
                 agencyName = agencyName
@@ -27,8 +42,7 @@ class AgencyRegisterViewModel @Inject constructor(
         }
     }
 
-
-    fun onAgencyTypeChanged(agencyType: AgencyType) = intent {
+    fun changeAgencyType(agencyType: AgencyType) = intent {
         reduce {
             state.copy(
                 agencyType = agencyType
@@ -44,29 +58,11 @@ class AgencyRegisterViewModel @Inject constructor(
         }
     }
 
-    fun onRegisterButtonClicked() = intent {
-        registerAgencyUseCase(
-            data = AgencyRegisterParam(
-                name = state.agencyName.text,
-                type = state.agencyType.toParam()
-            )
-        ).onSuccess {
-            postSideEffect(AgencyRegisterSideEffect.NavigateToComplete)
-        }.onFailure {
-            // TODO: 에러 처라
-        }
-    }
-
-
-    fun changeVisibleDialog(visible: Boolean) = intent {
+    fun changeOutDialogVisibility(visible: Boolean) = intent {
         reduce {
             state.copy(
                 visibleOutDialog = visible
             )
         }
-    }
-
-    fun onDialogPositiveButtonClicked() {
-        eventEmit(AgencyRegisterSideEffect.NavigateUp)
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/complete/AgencyRegisterCompleteScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/complete/AgencyRegisterCompleteScreen.kt
@@ -72,7 +72,7 @@ fun AgencyRegisterCompleteScreen(
             .background(color = Gray08)
             .padding(horizontal = MMHorizontalSpacing)
     ) {
-        TitleView(onBackClick = viewModel::onBackButtonClicked)
+        TitleView(onBackClick = viewModel::navigateToAgencySearch)
         ContentView(
             modifier = Modifier
                 .weight(1f)
@@ -80,7 +80,7 @@ fun AgencyRegisterCompleteScreen(
         )
         MDSButton(
             modifier = Modifier.fillMaxWidth(),
-            onClick = viewModel::onNavigateLedgerButtonClicked,
+            onClick = viewModel::navigateToLedger,
             text = "소속 장부 확인하러 가기",
             type = MDSButtonType.SECONDARY
         )

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/complete/AgencyRegisterCompleteViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/complete/AgencyRegisterCompleteViewModel.kt
@@ -10,11 +10,9 @@ class AgencyRegisterCompleteViewModel @Inject constructor() :
         AgencyRegisterCompleteState
     ) {
 
-    fun onNavigateLedgerButtonClicked() {
-        eventEmit(AgencyRegisterCompleteSideEffect.NavigateToLedger)
-    }
+    fun navigateToLedger() =
+        eventEmit(sideEffect = AgencyRegisterCompleteSideEffect.NavigateToLedger)
 
-    fun onBackButtonClicked() {
-        eventEmit(AgencyRegisterCompleteSideEffect.NavigateToAgencySearch)
-    }
+    fun navigateToAgencySearch() =
+        eventEmit(sideEffect = AgencyRegisterCompleteSideEffect.NavigateToAgencySearch)
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -15,10 +15,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -30,7 +28,6 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import com.moneymong.moneymong.design_system.R
-import com.moneymong.moneymong.design_system.component.bottomSheet.MDSBottomSheet
 import com.moneymong.moneymong.design_system.component.button.MDSFloatingActionButton
 import com.moneymong.moneymong.design_system.component.tooltip.MDSToolTip
 import com.moneymong.moneymong.design_system.component.tooltip.MDSToolTipPosition
@@ -41,41 +38,16 @@ import com.moneymong.moneymong.design_system.theme.MMHorizontalSpacing
 import com.moneymong.moneymong.design_system.theme.Red03
 import com.moneymong.moneymong.design_system.theme.White
 import com.moneymong.moneymong.feature.agency.Agency
-import com.moneymong.moneymong.feature.agency.search.component.AgencySearchBottomSheetContent
 import com.moneymong.moneymong.feature.agency.search.component.AgencySearchTopBar
 import com.moneymong.moneymong.feature.agency.search.item.AgencyItem
-import org.orbitmvi.orbit.compose.collectAsState
-import org.orbitmvi.orbit.compose.collectSideEffect
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AgencySearchScreen(
     modifier: Modifier = Modifier,
     viewModel: AgencySearchViewModel = hiltViewModel(),
     navigateToRegister: () -> Unit
 ) {
-    val state by viewModel.collectAsState()
     val pagingItems = viewModel.agencies.collectAsLazyPagingItems()
-
-    viewModel.collectSideEffect {
-        when (it) {
-            is AgencySearchSideEffect.NavigateToRegister -> {
-                navigateToRegister()
-            }
-        }
-    }
-
-    if (state.visibleBottomSheet) {
-        MDSBottomSheet(
-            onDismissRequest = viewModel::onDismissBottomSheet,
-        ) {
-            AgencySearchBottomSheetContent(
-                checkedType = state.registerType,
-                changeType = viewModel::changeRegisterType,
-                onConfirm = viewModel::onBottomSheetConfirmButtonClicked
-            )
-        }
-    }
 
     Box(
         modifier = modifier
@@ -107,7 +79,7 @@ fun AgencySearchScreen(
                 Spacer(modifier = Modifier.height(8.dp))
             }
             MDSFloatingActionButton(
-                onClick = { viewModel.changeVisibleBottomSheet(true) },
+                onClick = navigateToRegister,
                 iconResource = R.drawable.ic_plus_default,
                 containerColor = Red03
             )

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchSideEffect.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchSideEffect.kt
@@ -1,7 +1,0 @@
-package com.moneymong.moneymong.feature.agency.search
-
-import com.moneymong.moneymong.common.base.SideEffect
-
-sealed interface AgencySearchSideEffect : SideEffect {
-    data object NavigateToRegister : AgencySearchSideEffect
-}

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
@@ -1,9 +1,0 @@
-package com.moneymong.moneymong.feature.agency.search
-
-import com.moneymong.moneymong.common.base.State
-import com.moneymong.moneymong.feature.agency.search.component.AgencyBottomSheetType
-
-data class AgencySearchState(
-    val visibleBottomSheet: Boolean = false,
-    val registerType: AgencyBottomSheetType? = null,
-) : State

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -1,56 +1,23 @@
 package com.moneymong.moneymong.feature.agency.search
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
-import com.moneymong.moneymong.common.base.BaseViewModel
 import com.moneymong.moneymong.domain.usecase.GetAgenciesUseCase
-import com.moneymong.moneymong.feature.agency.search.component.AgencyBottomSheetType
 import com.moneymong.moneymong.feature.agency.toAgency
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
-import org.orbitmvi.orbit.syntax.simple.intent
-import org.orbitmvi.orbit.syntax.simple.reduce
 import javax.inject.Inject
 
 @HiltViewModel
 class AgencySearchViewModel @Inject constructor(
     getAgenciesUseCase: GetAgenciesUseCase,
-) : BaseViewModel<AgencySearchState, AgencySearchSideEffect>(AgencySearchState()) {
+) : ViewModel() {
 
     val agencies = getAgenciesUseCase().cachedIn(viewModelScope).map { pagingData ->
         pagingData.map {
             it.toAgency()
         }
-    }
-
-    fun changeVisibleBottomSheet(visible: Boolean) = intent {
-        reduce {
-            state.copy(
-                visibleBottomSheet = visible
-            )
-        }
-    }
-
-    fun changeRegisterType(type: AgencyBottomSheetType?) = intent {
-        reduce {
-            state.copy(
-                registerType = type
-            )
-        }
-    }
-
-    fun onDismissBottomSheet() = intent {
-        reduce {
-            state.copy(
-                visibleBottomSheet = false,
-                registerType = null
-            )
-        }
-    }
-
-    fun onBottomSheetConfirmButtonClicked() {
-        eventEmit(AgencySearchSideEffect.NavigateToRegister)
-        onDismissBottomSheet()
     }
 }


### PR DESCRIPTION
## 요약
소속 등록, 조회 로직을 서버와 연동했습니다!🙂

## 작업내용
- 소속 등록 타입 선택 BottomSheet 제거
- API 및 datasourceimpl 구현

### 실행 영상
![KakaoTalk_20240123_203358694](https://github.com/YAPP-Github/23rd-Android-Team-2-Android/assets/80373033/dc339ca3-d86f-4efe-83bb-5c5707275579)


## 기타
- 변경된 UI 는 없습니다!
- `AgencySearch` 의 `BottomSheet` 을 제거하면서 `State(data class)` 에 정의할 상태가 없어져 state 와 sideEffect 를 제거했습니다!